### PR TITLE
Add archived link option

### DIFF
--- a/apps/web/components/dashboard/preview/BookmarkPreview.tsx
+++ b/apps/web/components/dashboard/preview/BookmarkPreview.tsx
@@ -61,6 +61,30 @@ function CreationTime({ createdAt }: { createdAt: Date }) {
   );
 }
 
+export function ExternalLinks({ url }: { url: string }) {
+  const { t } = useTranslation();
+  return (
+    <>
+      <Link
+        href={url}
+        target="_blank"
+        className="flex items-center gap-2 text-gray-400"
+      >
+        <span>{t("preview.view_original")}</span>
+        <ExternalLink />
+      </Link>
+      <Link
+        href={`https://web.archive.org/web/${encodeURIComponent(url)}`}
+        target="_blank"
+        className="flex items-center gap-2 text-gray-400"
+      >
+        <span>{t("preview.view_archived")}</span>
+        <ExternalLink />
+      </Link>
+    </>
+  );
+}
+
 export default function BookmarkPreview({
   bookmarkId,
   initialData,
@@ -129,16 +153,7 @@ export default function BookmarkPreview({
             {title === undefined || title === "" ? "Untitled" : title}
           </p>
         </div>
-        {sourceUrl && (
-          <Link
-            href={sourceUrl}
-            target="_blank"
-            className="flex items-center gap-2 text-gray-400"
-          >
-            <span>{t("preview.view_original")}</span>
-            <ExternalLink />
-          </Link>
-        )}
+        {sourceUrl && <ExternalLinks url={sourceUrl} />}
         <Separator />
       </div>
       <CreationTime createdAt={bookmark.createdAt} />

--- a/apps/web/components/dashboard/preview/__tests__/ExternalLinks.test.tsx
+++ b/apps/web/components/dashboard/preview/__tests__/ExternalLinks.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { ExternalLinks } from "../BookmarkPreview";
+
+describe("ExternalLinks", () => {
+  it("renders archive link", () => {
+    const url = "https://example.com";
+    render(<ExternalLinks url={url} />);
+    const archive = screen.getByText(/View Archived/i);
+    expect(archive).toHaveAttribute(
+      "href",
+      `https://web.archive.org/web/${encodeURIComponent(url)}`,
+    );
+  });
+});

--- a/apps/web/lib/i18n/locales/en/translation.json
+++ b/apps/web/lib/i18n/locales/en/translation.json
@@ -367,6 +367,7 @@
   },
   "preview": {
     "view_original": "View Original",
+    "view_archived": "View Archived",
     "cached_content": "Cached Content",
     "reader_view": "Reader View",
     "tabs": {

--- a/apps/web/lib/i18n/locales/en_US/translation.json
+++ b/apps/web/lib/i18n/locales/en_US/translation.json
@@ -437,6 +437,7 @@
   },
   "preview": {
     "view_original": "View Original",
+    "view_archived": "View Archived",
     "cached_content": "Cached Content",
     "reader_view": "Reader View",
     "tabs": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -109,6 +109,7 @@
     "autoprefixer": "^10.4.17",
     "postcss": "^8.4.35",
     "tailwindcss": "^3.4.1",
+    "@testing-library/react": "^14.2.1",
     "vite-tsconfig-paths": "^4.3.1",
     "vitest": "^1.6.1"
   },

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -7,6 +7,7 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   plugins: [tsconfigPaths()],
   test: {
+    environment: "jsdom",
     alias: {
       "@/*": "./*",
     },


### PR DESCRIPTION
## Summary
- add ExternalLinks with archived link option via web.archive.org
- support translations for the new option
- update vitest config for jsdom environment
- include unit test for ExternalLinks

## Testing
- `pnpm lint` *(fails: command exited with errors)*
- `pnpm typecheck` *(fails: command exited with errors)*
- `pnpm --filter @karakeep/web test` *(fails: Failed to resolve import "@testing-library/react")*


------
https://chatgpt.com/codex/tasks/task_e_6842c38353a0832684ed212995a0b611